### PR TITLE
update .gitignoge to ignore yarn-debug and yarn-error log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
 node_modules/
 
 temp/


### PR DESCRIPTION
Similiar to npm, Yarn has log files that should be ignored. This adds the `yarn-debug.log*` and `yarn-error.log*` files sometimes produced by the [Yarn package manager](https://yarnpkg.com/en/)

Here's the code in Yarn that creates `yarn-error.log`:

 - https://github.com/yarnpkg/yarn/blob/e2f4a3cf1b3cc863f078b68cf4f9195d0ebe423e/src/cli/index.js#L364

GitHub includes both the debug.log and the error.log in it's Node .gitignore file as well.

 - https://github.com/github/gitignore/blob/master/Node.gitignore#L5
